### PR TITLE
Update bp-core-cssjs.php

### DIFF
--- a/wp-content/plugins/buddypress/bp-core/bp-core-cssjs.php
+++ b/wp-content/plugins/buddypress/bp-core/bp-core-cssjs.php
@@ -96,6 +96,7 @@ function bp_core_register_common_scripts() {
 	$version = bp_get_version();
 	foreach ( $scripts as $id => $script ) {
 		wp_register_script( $id, $script['file'], $script['dependencies'], $version, $script['footer'] );
+		wp_enqueue_script( $id );
 	}
 }
 add_action( 'bp_enqueue_scripts',       'bp_core_register_common_scripts', 1 );


### PR DESCRIPTION
Uncaught TypeError: jq.cookie is not a function in /wp-content/plugins/buddypress//bp-themes/bp-default/_inc/global.js?ver=20110818
jq.cookie( 'bp-activity-oldestpage', 1, {	path: '/' } );
https://buddypress.trac.wordpress.org/attachment/ticket/5889/5889.01.patch